### PR TITLE
Add tuple type support

### DIFF
--- a/language/polkavm/examples/basic/sources/tuple.move
+++ b/language/polkavm/examples/basic/sources/tuple.move
@@ -1,0 +1,11 @@
+module 0x1234::tuplebasic {
+    // this should be enough to check tuple structuring/destructuring
+    fun giveMeTuple(a: u64, b: u32): (u64, u32) {
+        (a, b)
+    }
+
+    public entry fun multiply(a: u64, b: u32): u64 {
+        let (x, y) = giveMeTuple(a, b);
+        x * (y as u64)
+    }
+}

--- a/language/polkavm/examples/basic/sources/tuple.move
+++ b/language/polkavm/examples/basic/sources/tuple.move
@@ -1,11 +1,14 @@
 module 0x1234::tuplebasic {
     // this should be enough to check tuple structuring/destructuring
-    fun giveMeTuple(a: u64, b: u32): (u64, u32) {
+    // TODO(tadas): removing public keyword compiles just fine, but LLVM phase still exports this function even if its marked as private
+    public fun giveMeTuple(a: u64, b: u32): (u64, u32) {
         (a, b)
     }
 
     public entry fun multiply(a: u64, b: u32): u64 {
         let (x, y) = giveMeTuple(a, b);
-        x * (y as u64)
+        // we cannot use any arithmetic ops here which can cause under/over flow as move compiler
+        // automatically inserts move_rt_abort fn call on such cases - we are not ready for this yet
+        x + (y as u64)
     }
 }

--- a/language/polkavm/examples/basic/sources/tuple.move
+++ b/language/polkavm/examples/basic/sources/tuple.move
@@ -1,14 +1,14 @@
 module 0x1234::tuplebasic {
     // this should be enough to check tuple structuring/destructuring
     // TODO(tadas): removing public keyword compiles just fine, but LLVM phase still exports this function even if its marked as private
-    public fun giveMeTuple(a: u64, b: u32): (u64, u32) {
+    public fun giveMeTuple(a: u32, b: u64): (u32, u64) {
         (a, b)
     }
 
-    public entry fun multiply(a: u64, b: u32): u64 {
+    public entry fun add(a: u32, b: u64): u64 {
         let (x, y) = giveMeTuple(a, b);
         // we cannot use any arithmetic ops here which can cause under/over flow as move compiler
         // automatically inserts move_rt_abort fn call on such cases - we are not ready for this yet
-        x + (y as u64)
+        (x as u64) + y
     }
 }

--- a/language/polkavm/move-to-polka/src/stackless/module_context.rs
+++ b/language/polkavm/move-to-polka/src/stackless/module_context.rs
@@ -694,8 +694,19 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
                 }
             }
             Type::Vector(_) => Some(self.rtty_cx.get_llvm_type_for_move_vector(self, tyvec)),
-            Type::Tuple(_) => {
-                todo!("{mty:?}")
+            Type::Tuple(types_vec) => {
+                let llvm_types = types_vec
+                    .iter()
+                    .map(|move_ty| {
+                        self.to_llvm_type(move_ty, &[])
+                            .expect(&format!("{move_ty:?} should be available"))
+                    })
+                    .collect::<Vec<_>>();
+                Some(
+                    self.llvm_cx
+                        .anonymous_struct_type(&llvm_types)
+                        .as_any_type(),
+                )
             }
             Type::Fun(_, _, _)
             | Type::TypeDomain(_)

--- a/language/polkavm/move-to-polka/src/stackless/module_context.rs
+++ b/language/polkavm/move-to-polka/src/stackless/module_context.rs
@@ -697,9 +697,9 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
             Type::Tuple(types_vec) => {
                 let llvm_types = types_vec
                     .iter()
-                    .map(|move_ty| {
-                        self.to_llvm_type(move_ty, &[])
-                            .expect(&format!("{move_ty:?} should be available"))
+                    .map(|move_type| {
+                        self.to_llvm_type(move_type, &[])
+                            .expect(&format!("{move_type:?} should be available"))
                     })
                     .collect::<Vec<_>>();
                 Some(

--- a/language/polkavm/move-to-polka/tests/examples_basic_test.rs
+++ b/language/polkavm/move-to-polka/tests/examples_basic_test.rs
@@ -76,7 +76,7 @@ pub fn test_basic_program_execution() -> anyhow::Result<()> {
 }
 
 #[test]
-pub fn test_tuple_implementatino() -> anyhow::Result<()> {
+pub fn test_tuple_implementation() -> anyhow::Result<()> {
     let build_options =
         BuildOptions::new("output/tuple.o").source("../examples/basic/sources/tuple.move");
 
@@ -102,7 +102,7 @@ pub fn test_tuple_implementatino() -> anyhow::Result<()> {
     // Grab the function and call it.
     println!("Calling into the guest program (high level):");
     let result = instance
-        .call_typed_and_get_result::<u64, (u64, u32)>(&mut (), "multiply", (10, 5))
+        .call_typed_and_get_result::<u64, (u32, u64)>(&mut (), "add", (10, 5))
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
     assert_eq!(result, 15);
 

--- a/language/polkavm/move-to-polka/tests/examples_basic_test.rs
+++ b/language/polkavm/move-to-polka/tests/examples_basic_test.rs
@@ -108,7 +108,7 @@ pub fn test_tuple_implementatino() -> anyhow::Result<()> {
     let result = instance
         .call_typed_and_get_result::<u64, (u64, u32)>(&mut (), "multiply", (10, 5))
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-    assert_eq!(result, 50);
+    assert_eq!(result, 15);
 
     Ok(())
 }

--- a/language/polkavm/move-to-polka/tests/examples_basic_test.rs
+++ b/language/polkavm/move-to-polka/tests/examples_basic_test.rs
@@ -76,3 +76,39 @@ pub fn test_basic_program_execution() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+pub fn test_tuple_implementatino() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let build_options =
+        BuildOptions::new("output/tuple.o").source("../examples/basic/sources/tuple.move");
+
+    let move_byte_code = build_move_program(build_options)?;
+    // polka tool linking phase
+    let program_bytes = load_from_elf_with_polka_linker(&move_byte_code)?;
+
+    let blob =
+        ProgramBlob::parse(program_bytes[..].into()).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+
+    let config = Config::from_env()?;
+    let engine = Engine::new(&config)?;
+    let module = Module::from_blob(&engine, &Default::default(), blob)?;
+
+    let linker: Linker = Linker::new();
+
+    // Link the host functions with the module.
+    let instance_pre = linker.instantiate_pre(&module)?;
+
+    // Instantiate the module.
+    let mut instance = instance_pre.instantiate()?;
+
+    // Grab the function and call it.
+    println!("Calling into the guest program (high level):");
+    let result = instance
+        .call_typed_and_get_result::<u64, (u64, u32)>(&mut (), "multiply", (10, 5))
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    assert_eq!(result, 50);
+
+    Ok(())
+}

--- a/language/polkavm/move-to-polka/tests/examples_basic_test.rs
+++ b/language/polkavm/move-to-polka/tests/examples_basic_test.rs
@@ -42,8 +42,6 @@ pub fn test_morebasic_program_execution() -> anyhow::Result<()> {
 #[test]
 #[ignore = "doesnt work yet - need further push LLVM implementation"]
 pub fn test_basic_program_execution() -> anyhow::Result<()> {
-    env_logger::init();
-
     let build_options = BuildOptions::new("output/basic.o")
         .source("../examples/basic/sources/basic.move")
         .dependency(&resolve_move_std_lib_sources())
@@ -79,8 +77,6 @@ pub fn test_basic_program_execution() -> anyhow::Result<()> {
 
 #[test]
 pub fn test_tuple_implementatino() -> anyhow::Result<()> {
-    env_logger::init();
-
     let build_options =
         BuildOptions::new("output/tuple.o").source("../examples/basic/sources/tuple.move");
 


### PR DESCRIPTION
Adds support on Tuple type in Move:
```move
fun to_tuple(a: int8, b: int8) : (int8 , int8) {
  (a, b)
}

... let (a , b) = to_tuple( 1 ,2)
```
check 