### PR TITLE
Add ci tests for windows-latest

### DIFF
--- a/.github/workflows/move-to-polka.yml
+++ b/.github/workflows/move-to-polka.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [1.84.1, nightly]
         exclude:
           # Segfaults in CI
@@ -58,6 +58,37 @@ jobs:
         run: |
           brew install llvm@19
 
+      - name: Install LLVM 19 and set environment on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          # Download LLVM installer
+          Invoke-WebRequest -Uri https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/LLVM-19.1.7-win64.exe -OutFile llvm-installer.exe
+
+          # Run the installer and check the exit code and expected files
+          $process = Start-Process -FilePath .\llvm-installer.exe -ArgumentList "/S", "/D=C:\LLVM" -Wait -PassThru
+          Write-Host "Installer exit code: $($process.ExitCode)"
+          if ($process.ExitCode -ne 0) {
+            Write-Host "Installation failed with exit code $($process.ExitCode)"
+            exit 1
+          }
+          Write-Host "Contents of C:\LLVM:"
+          Get-ChildItem "C:\LLVM" -ErrorAction Stop
+          Write-Host "Contents of C:\LLVM\bin:"
+          Get-ChildItem "C:\LLVM\bin" -ErrorAction Stop
+
+          # llvm-config is key for the Rust crate llvm-sys to work
+          if (-not (Test-Path "C:\LLVM\bin\llvm-config.exe")) {
+            Write-Host "llvm-config.exe not found in C:\LLVM\bin"
+            exit 1
+          }
+
+          # Append LLVM bin directory to PATH
+          echo "C:\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+          # Set LLVM_SYS_191_PREFIX environment variable
+          echo "LLVM_SYS_191_PREFIX=C:\LLVM" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
+
       - name: Install Rust
         if: matrix.rust != 'nightly'
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -65,19 +96,18 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy, rustfmt
 
-      - name: Install Rust miri if nightly
+      - name: Install Rust - including miri
         if: matrix.rust == 'nightly'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          components: miri
+          components: clippy, rustfmt, miri
 
       - name: Check formatting
-        if: matrix.rust == '1.84.1'
         run: cargo fmt -- --check
 
       - name: Lint with Clippy
-        if: matrix.rust == '1.84.1'
+        if: matrix.rust != 'nightly'
         run: cargo clippy -- -D warnings
 
       - name: Build


### PR DESCRIPTION
We are lucky. LLVM 19 is already installed in the windows-latest machine. [docs](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md#language-and-runtime).

Moreover, rustup is also included directly.