### PR TITLE
Add nightly in addition to 1.84.1 in CI workflow matrix

### DIFF
--- a/.github/workflows/move-to-polka.yml
+++ b/.github/workflows/move-to-polka.yml
@@ -15,8 +15,17 @@ jobs:
     name: Build and Test move-to-polka
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        rust: [1.84.1, nightly]
+        exclude:
+          # Segfaults in CI
+          - os: macos-latest
+            rust: nightly
+
+    env:
+      cache_version: 1
 
     defaults:
       run:
@@ -32,9 +41,9 @@ jobs:
         with:
           path: |
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ env.cache_version }}-${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ env.cache_version }}-$${{ runner.os }}-cargo-${{ matrix.rust }}-
 
       - name: Install LLVM 19 on Ubuntu
         if: matrix.os == 'ubuntu-latest'
@@ -44,29 +53,45 @@ jobs:
           llvm-config-19 --version
           sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/lld-19 100
 
-      - name: Install Rustup and LLVM 19 on MacOS
+      - name: Install LLVM 19 on MacOS
         if: matrix.os == 'macos-latest'
         run: |
           brew install llvm@19
 
       - name: Install Rust
-        run: |
-          rustup toolchain install 1.84.1
-          rustup default 1.84.1
-          rustup component add rustfmt clippy
+        if: matrix.rust != 'nightly'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: clippy, rustfmt
+
+      - name: Install Rust miri if nightly
+        if: matrix.rust == 'nightly'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: miri
 
       - name: Check formatting
+        if: matrix.rust == '1.84.1'
         run: cargo fmt -- --check
+
+      - name: Lint with Clippy
+        if: matrix.rust == '1.84.1'
+        run: cargo clippy -- -D warnings
 
       - name: Build
         run: cargo build --verbose
-
-      - name: Lint with Clippy
-        run: cargo clippy -- -D warnings
 
       - name: Enable unprivileged user namespaces
         if: matrix.os == 'ubuntu-latest'
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Run tests
+        env:
+          RUST_BACKTRACE: full
         run: cargo test --verbose
+
+      # - name: Test with Miri on nightly
+      #   if: matrix.rust == 'nightly'
+      #   run: cargo miri test


### PR DESCRIPTION
In addition to 1.84.1 we also test on Rust nightly. This will give us a higher quality in general. Moreover, we can later use miri in the workflow.