### PR TITLE
fix: find the move-std lib crate inside .cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -410,6 +410,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2193,6 +2225,7 @@ dependencies = [
  "atty",
  "blake3",
  "bs58",
+ "cargo_metadata",
  "chrono",
  "clap 4.5.30",
  "codespan",
@@ -2214,6 +2247,7 @@ dependencies = [
  "move-model",
  "move-native",
  "move-stackless-bytecode",
+ "move-stdlib",
  "move-symbol-pool",
  "num",
  "num-traits",
@@ -2226,6 +2260,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.11",
  "which",
 ]
 
@@ -3131,6 +3166,9 @@ name = "semver"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/language/polkavm/move-to-polka/Cargo.toml
+++ b/language/polkavm/move-to-polka/Cargo.toml
@@ -49,3 +49,8 @@ which = "7.0"
 [dev-dependencies]
 polkavm = "0.22.0"
 polkavm-linker = "0.22.0"
+
+[build-dependencies]
+move-stdlib = { git = "https://github.com/move-language/move-on-aptos.git", package = "move-stdlib" }
+cargo_metadata = "0.19"
+thiserror = "2.0"

--- a/language/polkavm/move-to-polka/build.rs
+++ b/language/polkavm/move-to-polka/build.rs
@@ -1,0 +1,30 @@
+// build.rs
+use cargo_metadata::{MetadataCommand, Package};
+
+fn main() {
+    let metadata = MetadataCommand::new()
+        .exec()
+        .expect("failed to fetch cargo metadata");
+
+    let git_prefix = "git+https://github.com/move-language/move-on-aptos.git";
+    let dep_pkg: &Package = metadata
+        .packages
+        .iter()
+        .find(|p| {
+            p.name == "move-stdlib"
+                && p.source
+                    .as_ref()
+                    .map(|s| s.repr.starts_with(git_prefix))
+                    .unwrap_or(false)
+        })
+        .expect("move-stdlib not found in cargo metadata");
+
+    let dep_dir = dep_pkg
+        .manifest_path
+        .parent()
+        .expect("manifest_path had no parent")
+        .to_path_buf();
+
+    println!("cargo:rustc-env=MOVE_STDLIB_PATH={}", dep_dir);
+    println!("cargo:rerun-if-changed={}", dep_dir);
+}

--- a/language/polkavm/move-to-polka/tests/common/mod.rs
+++ b/language/polkavm/move-to-polka/tests/common/mod.rs
@@ -76,16 +76,7 @@ pub fn build_move_program(options: BuildOptions) -> anyhow::Result<Vec<u8>> {
     let data = std::fs::read(output_file)?;
     Ok(data)
 }
-
-pub fn resolve_move_std_lib_sources() -> String {
-    //TODO(tadas): Right now we expect that move-stdlib comes from move-on-aptos checked out on the same root level as this project itself
-    //BUT since we depend on some rust crates coming from move-on-aptos repo, repo itself is available as cargo checkouts dir
-    //it would be awesome to:
-    // 1. scan cargo lock (cargo_metadata crate?) to find exact revision of move-on-aptos
-    // 2. lookup cargo home dir according to rules (respect CARGO_HOME , default to HOME/.cargo if not set)
-    // lookup actual move-on-aptos dependency and navigate to move-stdlib sources!
-    "../../../../move-on-aptos/language/move-stdlib/sources".to_string()
-}
+pub const MOVE_STDLIB_PATH: &str = env!("MOVE_STDLIB_PATH");
 
 pub fn create_dir_all<T: AsRef<Path>>(path: T) -> anyhow::Result<()> {
     if let Some(parent) = path.as_ref().parent() {

--- a/language/polkavm/move-to-polka/tests/examples_basic_test.rs
+++ b/language/polkavm/move-to-polka/tests/examples_basic_test.rs
@@ -39,9 +39,10 @@ pub fn test_morebasic_program_execution() -> anyhow::Result<()> {
 #[test]
 #[ignore = "doesnt work yet - need further push LLVM implementation"]
 pub fn test_basic_program_execution() -> anyhow::Result<()> {
+    let move_src = format!("{}/sources", MOVE_STDLIB_PATH);
     let build_options = BuildOptions::new("output/basic.o")
         .source("../examples/basic/sources/basic.move")
-        .dependency(&resolve_move_std_lib_sources())
+        .dependency(&move_src)
         .address_mapping("std=0x1");
 
     let move_byte_code = build_move_program(build_options)?;


### PR DESCRIPTION
This fixes the need for user to have to checkout move manually.