### PR TITLE
fix: add serial annotation on test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,6 +2257,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.12",
 ]
@@ -3236,10 +3237,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "semver"
@@ -3321,6 +3337,31 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/language/polkavm/move-to-polka/Cargo.toml
+++ b/language/polkavm/move-to-polka/Cargo.toml
@@ -46,6 +46,7 @@ hex = "0.4"
 
 [dev-dependencies]
 polkavm = "0.23.0"
+serial_test = "3.2.0"
 
 [build-dependencies]
 move-stdlib = { git = "https://github.com/move-language/move-on-aptos.git", package = "move-stdlib" }

--- a/language/polkavm/move-to-polka/tests/examples_basic_test.rs
+++ b/language/polkavm/move-to-polka/tests/examples_basic_test.rs
@@ -3,8 +3,10 @@ use polkavm::{Config, Engine, Linker, Module};
 
 mod common;
 use common::*;
+use serial_test::serial;
 
 #[test]
+#[serial] // TODO: find the reason this needs to run serially on macOS
 pub fn test_morebasic_program_execution() -> anyhow::Result<()> {
     let build_options = BuildOptions::new("output/morebasic.polkavm")
         .source("../examples/basic/sources/morebasic.move");
@@ -71,6 +73,7 @@ pub fn test_basic_program_execution() -> anyhow::Result<()> {
 }
 
 #[test]
+#[serial]
 pub fn test_tuple_implementation() -> anyhow::Result<()> {
     let build_options =
         BuildOptions::new("output/tuple.polkavm").source("../examples/basic/sources/tuple.move");


### PR DESCRIPTION
This fixes the SIGSEGV on macOS. We need to figure out why this fails in multithreaded runs.