### PR TITLE
fix: remove obsolete FIXME

### DIFF
--- a/language/polkavm/move-to-polka/src/lib.rs
+++ b/language/polkavm/move-to-polka/src/lib.rs
@@ -300,9 +300,6 @@ pub fn compile(global_env: &GlobalEnv, options: &Options) -> anyhow::Result<()> 
             &options.move_native_archive,
         )?;
     }
-    // FIXME: this should be handled with lifetimes.
-    // Context (global_cx) must outlive llvm module (entry_llmod).
-    drop(global_cx);
     Ok(())
 }
 


### PR DESCRIPTION
The other variable got removed in the solana cleanup. This is no longer needed.