### PR TITLE
test: add test

### DIFF
--- a/language/polkavm/examples/multi_module/sources/modules.move
+++ b/language/polkavm/examples/multi_module/sources/modules.move
@@ -23,8 +23,9 @@ module multi_module::A {
 module multi_module::B {
     use 0x10::debug;
 
-    public entry fun foo_bar() {
-        let val = 17;
+    public entry fun foo_bar(): u64 {
+        let val = 42;
         debug::print(&val);
+        val
     }
 }


### PR DESCRIPTION
add modules.move test. I had to change the return value of `B::foo_bar` to `u64`, as the compiler seems to choke on void return type.