### PR TITLE
chore: let ENV var decide whether to enable logging or not

### DIFF
--- a/language/polkavm/move-to-polka/src/lib.rs
+++ b/language/polkavm/move-to-polka/src/lib.rs
@@ -45,7 +45,6 @@ pub fn initialize_logger() {
     LOGGER_INIT.call_once(|| {
         use anstyle::{AnsiColor, Color};
         env_logger::Builder::new()
-            .filter_level(log::LevelFilter::Info)
             .parse_default_env()
             .format(|formatter, record| {
                 let level = record.level();


### PR DESCRIPTION
To not pollute output of test runs, don't automatically set a logging level. User can always use `RUST_LOG` env var to enable.