### PR TITLE
feat: add mul/div test

### DIFF
--- a/language/polkavm/examples/basic/sources/arith.move
+++ b/language/polkavm/examples/basic/sources/arith.move
@@ -1,0 +1,12 @@
+module 0xa000::basic {
+
+    public entry fun div(a: u64, b:u64): u64 {
+        assert!(b != 0, 0x1001);
+        a / b
+    }
+
+    public entry fun mul(a: u64, b:u64): u64 {
+        a * b
+    }
+
+}

--- a/language/polkavm/move-to-polka/src/stackless/llvm.rs
+++ b/language/polkavm/move-to-polka/src/stackless/llvm.rs
@@ -351,7 +351,7 @@ impl Module {
         ty: FunctionType,
         polka_export: bool,
     ) -> Function {
-        log::debug!("Adding function {name}");
+        log::debug!("Adding function {module}:{name}");
         unsafe {
             let hash = hash_string(format!("{module}::{name}").as_str());
             let mangled = format!(
@@ -389,7 +389,22 @@ impl Module {
             if !llfn.is_null() {
                 Some(Function(llfn))
             } else {
-                None
+                let module = "native";
+                let hash = hash_string(format!("{module}::{name}").as_str());
+                let mangled = format!(
+                    "_ZN{}{}{}{}17h{}E",
+                    module.len(),
+                    module,
+                    name.len(),
+                    name,
+                    hash
+                );
+                let llfn = LLVMGetNamedFunction(self.0, mangled.cstr());
+                if !llfn.is_null() {
+                    Some(Function(llfn))
+                } else {
+                    None
+                }
             }
         }
     }

--- a/language/polkavm/move-to-polka/tests/examples_basic_test.rs
+++ b/language/polkavm/move-to-polka/tests/examples_basic_test.rs
@@ -63,6 +63,18 @@ pub fn test_arith() -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
     assert_eq!(result, 36);
 
+    // div by zero and overflow should fail
+    let result = instance
+        .call_typed_and_get_result::<u64, (u64, u64)>(&mut (), "div", (12, 0))
+        .map_err(|e| anyhow::anyhow!("{e:?}"));
+    assert!(result.is_err());
+
+    // overflow on multiplication should fail
+    let result = instance
+        .call_typed_and_get_result::<u64, (u64, u64)>(&mut (), "mul", (u64::MAX, 2))
+        .map_err(|e| anyhow::anyhow!("{e:?}"));
+    assert!(result.is_err());
+
     Ok(())
 }
 

--- a/language/polkavm/move-to-polka/tests/examples_basic_test.rs
+++ b/language/polkavm/move-to-polka/tests/examples_basic_test.rs
@@ -29,6 +29,7 @@ pub fn test_morebasic_program_execution() -> anyhow::Result<()> {
 }
 
 #[test]
+#[serial]
 pub fn test_void_program_execution() -> anyhow::Result<()> {
     let mut instance = build_instance(
         "output/void.polkavm",
@@ -45,6 +46,7 @@ pub fn test_void_program_execution() -> anyhow::Result<()> {
 }
 
 #[test]
+#[serial]
 pub fn test_arith() -> anyhow::Result<()> {
     let mut instance = build_instance(
         "output/arith.polkavm",

--- a/language/polkavm/move-to-polka/tests/examples_basic_test.rs
+++ b/language/polkavm/move-to-polka/tests/examples_basic_test.rs
@@ -45,6 +45,26 @@ pub fn test_void_program_execution() -> anyhow::Result<()> {
 }
 
 #[test]
+pub fn test_arith() -> anyhow::Result<()> {
+    let mut instance = build_instance(
+        "output/arith.polkavm",
+        "../examples/basic/sources/arith.move",
+        vec!["std=0x1"],
+    )?;
+    let result = instance
+        .call_typed_and_get_result::<u64, (u64, u64)>(&mut (), "div", (12, 3))
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    assert_eq!(result, 4);
+
+    let result = instance
+        .call_typed_and_get_result::<u64, (u64, u64)>(&mut (), "mul", (12, 3))
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    assert_eq!(result, 36);
+
+    Ok(())
+}
+
+#[test]
 #[serial]
 pub fn test_basic_program_execution() -> anyhow::Result<()> {
     initialize_logger();


### PR DESCRIPTION
add test for division/multiplication. This lead to an issue where `move_rt_abort` was redefined several times as the code looks up the function with 'normal' name, but defines it as mangled.

HACK: lookup with mangled name in 'native' module if not found by name.