### PR TITLE
Fix/struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2786,9 +2786,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
 dependencies = [
  "bitflags",
  "libc",
@@ -2934,7 +2934,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "bcs",
@@ -2951,7 +2951,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2966,12 +2966,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "bcs",
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "once_cell",
  "quote",
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "difference",
@@ -3039,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3064,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -3098,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "clap",
@@ -3156,7 +3156,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "clap",
@@ -3175,7 +3175,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "hex",
@@ -3218,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "codespan",
@@ -3258,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "clap",
@@ -3292,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "atty",
@@ -3319,7 +3319,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3348,7 +3348,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -3364,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "anyhow",
  "hex",
@@ -3409,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "once_cell",
  "serde",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "move-vm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "ambassador",
  "better_any",
@@ -3501,7 +3501,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/move-on-aptos.git#e9ead8f2649927ccb5399c089ca6d64b6aef6279"
+source = "git+https://github.com/eigerco/move-on-aptos.git#deb3b8991cdc456c68f424b7a486d544260994fa"
 dependencies = [
  "ambassador",
  "bcs",
@@ -4312,9 +4312,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -4509,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.30"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "ring",
@@ -5888,7 +5888,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -5924,10 +5924,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,7 @@ dependencies = [
  "bs58",
  "build-tools",
  "cargo_metadata",
+ "chrono",
  "clap",
  "codespan",
  "codespan-reporting",

--- a/crates/move-to-polka/Cargo.toml
+++ b/crates/move-to-polka/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4.5", features = ["derive"] }
 # we can not upgrade the next 2 until aptos-move updates
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"
+chrono = { version = "0.4" }
 anstyle = "1.0"
 env_logger = { version = "0.11", features = ["color"] }
 extension-trait = "1.0.1"

--- a/crates/move-to-polka/src/lib.rs
+++ b/crates/move-to-polka/src/lib.rs
@@ -57,7 +57,8 @@ pub fn initialize_logger() {
                 };
                 writeln!(
                     formatter,
-                    "[{} {}:{}] {}",
+                    "{} [{} {}:{}] {}",
+                    chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
                     level,
                     record.target(),
                     record.line().unwrap_or(0),

--- a/crates/move-to-polka/src/stackless/llvm.rs
+++ b/crates/move-to-polka/src/stackless/llvm.rs
@@ -22,6 +22,7 @@ use num_traits::{PrimInt, ToPrimitive};
 use crate::cstr::SafeCStr;
 
 use std::{
+    backtrace::Backtrace,
     cell::RefCell,
     ffi::{CStr, CString},
     hash::DefaultHasher,
@@ -198,6 +199,8 @@ impl Context {
     }
 
     pub fn create_opaque_named_struct(&self, name: &str) -> StructType {
+        let bt = Backtrace::capture();
+        debug!(target: "struct", "create_opaque_named_struct {name}: {bt:#?}");
         unsafe { StructType(LLVMStructCreateNamed(self.0, name.cstr())) }
     }
 
@@ -1271,6 +1274,8 @@ impl StructType {
     }
 
     pub fn set_struct_body(&self, field_tys: &[Type]) {
+        let bt = Backtrace::capture();
+        debug!("set_struct_body called: {bt:#?}");
         unsafe {
             let mut field_tys: Vec<_> = field_tys.iter().map(|f| f.0).collect();
             LLVMStructSetBody(

--- a/crates/move-to-polka/src/stackless/llvm.rs
+++ b/crates/move-to-polka/src/stackless/llvm.rs
@@ -1156,10 +1156,11 @@ impl Builder {
     }
 
     /// Return an `i1` which is true if `val` is null/zero.
-    /// Works on both pointer‐ and integer‐typed values.
-    pub fn build_is_null(&self, val: LLVMValueRef, name: &str) -> AnyValue {
+    /// Works on both pointer- and integer-typed values.
+    pub fn build_is_null(&self, val: AnyValue, name: &str) -> AnyValue {
         let c_name = CString::new(name).expect("no interior NULs in name");
         unsafe {
+            let val = val.0;
             let ty = LLVMTypeOf(val);
             let zero = LLVMConstNull(ty);
             AnyValue(LLVMBuildICmp(self.0, LLVMIntEQ, val, zero, c_name.as_ptr()))

--- a/crates/move-to-polka/src/stackless/llvm.rs
+++ b/crates/move-to-polka/src/stackless/llvm.rs
@@ -15,7 +15,7 @@
 
 use libc::abort;
 use llvm_sys::{core::*, prelude::*, target::*, target_machine::*, LLVMOpcode, LLVMUnnamedAddr};
-use log::{debug, trace, warn};
+use log::{debug, warn};
 use move_core_types::u256;
 use num_traits::{PrimInt, ToPrimitive};
 
@@ -1275,7 +1275,7 @@ impl StructType {
 
     pub fn set_struct_body(&self, field_tys: &[Type]) {
         let bt = Backtrace::capture();
-        debug!("set_struct_body called: {bt:#?}");
+        debug!("set_struct_body called types: {field_tys:?}: {bt:#?}");
         unsafe {
             let mut field_tys: Vec<_> = field_tys.iter().map(|f| f.0).collect();
             LLVMStructSetBody(
@@ -1394,10 +1394,10 @@ impl Function {
     pub fn verify(&self, module_cx: &ModuleContext<'_, '_>) {
         use llvm_sys::analysis::*;
         let module_info = module_cx.llvm_module.print_to_str();
-        trace!(target: "verify function", "Module content:");
-        trace!(target: "verify function", "------------------------------");
-        trace!(target: "verify function", "{module_info}");
-        trace!(target: "verify function", "------------------------------");
+        debug!(target: "verify function", "Module content:");
+        debug!(target: "verify function", "------------------------------");
+        debug!(target: "verify function", "{module_info}");
+        debug!(target: "verify function", "------------------------------");
         unsafe {
             if LLVMVerifyFunction(self.0, LLVMVerifierFailureAction::LLVMPrintMessageAction) == 1 {
                 println!("{} function verifiction failed", &self.get_name());

--- a/crates/move-to-polka/src/stackless/module_context.rs
+++ b/crates/move-to-polka/src/stackless/module_context.rs
@@ -358,14 +358,14 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
                    "Declaring struct instance {} attrs {:?} with tys {:?}",
                    s_env.get_full_name_str(),
                    s_env.get_fields().map(|f| f.get_type()).collect::<Vec<_>>(),
-                   tys);
+                   tyvec);
             self.translate_struct(&s_env, tyvec);
             let llvm_ty = self.to_llvm_type(mty, tyvec).unwrap();
             debug!(target: "structs",
                    "Declared struct instance {} with llvm type {:?} -> {:?}",
                    s_env.get_full_name_str(),
                    llvm_ty,
-                   s_env.ll_struct_name_from_raw_name(tys));
+                   s_env.ll_struct_name_from_raw_name(tyvec));
             llvm_ty
         } else {
             unreachable!("Failed to declare a struct {mty:?}")
@@ -880,15 +880,15 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
                     let struct_env = global_env
                         .get_module(declaring_module_id)
                         .into_struct(struct_id);
-                    let struct_name = struct_env.ll_struct_name_from_raw_name(&tys);
+                    let struct_name = struct_env.ll_struct_name_from_raw_name(tys);
                     debug!(
-                        target: "structs", "llvm type for struct {:?} is '{}'", &new_sty, struct_name);
+                        target: "structs", "llvm type for struct {:?}::{:?} is '{}'", &struct_env.module_env.get_name(), &new_sty, struct_name);
                     if let Some(stype) = self.llvm_cx.named_struct_type(&struct_name) {
                         debug!( target: "structs", "struct type for '{}' found", &struct_name);
                         Some(stype.as_any_type())
                     } else {
                         debug!(target: "structs", "struct type for '{}' not found", &struct_name);
-                        None
+                        Some(self.declare_struct_instance(mty, tys))
                     }
                 } else {
                     unreachable!("")

--- a/crates/move-to-polka/src/stackless/module_context.rs
+++ b/crates/move-to-polka/src/stackless/module_context.rs
@@ -347,7 +347,7 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
     // This method is used to declare structs found when function
     // declrations are generated and new instantiations of generic
     // structs become known.
-    // TODO: porbably other parameterized types such as Vector should
+    // TODO: probably other parameterized types such as Vector should
     // be handled by this function too.
     pub fn declare_struct_instance(&self, mty: &mty::Type, tyvec: &[mty::Type]) -> llvm::Type {
         debug!(target: "structs", "Declaring struct instance {mty:?} with tys {tyvec:?} bt: {:#?}", std::backtrace::Backtrace::capture());

--- a/crates/move-to-polka/src/stackless/module_context.rs
+++ b/crates/move-to-polka/src/stackless/module_context.rs
@@ -109,6 +109,10 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
         while let Some(mid) = worklist.pop_front() {
             let compiled_module = m_env.get_verified_module().unwrap();
             for shandle in compiled_module.struct_handles() {
+                debug!(target: "structs",
+                       "Found struct handle {} in module {}",
+                       shandle.name,
+                       &shandle.module);
                 let struct_view = StructHandleView::new(compiled_module, shandle);
                 let declaring_module_env = g_env
                     .find_module(&g_env.to_module_name(&struct_view.module_id()))
@@ -116,14 +120,20 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
                 let struct_env = declaring_module_env
                     .find_struct(m_env.symbol_pool().make(struct_view.name().as_str()))
                     .expect("undefined struct");
+                debug!(target: "structs",
+                       "Found struct {} in module {}",
+                       struct_env.get_full_name_str(),
+                       declaring_module_env.get_full_name_str());
                 let qid = struct_env.get_qualified_id();
                 if qid.module_id != m_env.get_id() && !visited.contains(&qid.module_id) {
+                    debug!(target: "structs", "inserting",);
                     worklist.push_back(qid.module_id);
                     external_sqids.insert(qid);
                 }
             }
             visited.insert(mid);
         }
+        debug!(target: "structs", "Found structs {visited:?} ");
 
         // Create a combined list of all structs (external plus local).
         //
@@ -131,6 +141,13 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
         // concrete structures). The expansions will occur later when the struct definition
         // instantiations are processed.
         let has_type_params = |s_env: &mm::StructEnv| !s_env.get_type_parameters().is_empty();
+        for s in m_env.get_structs() {
+            debug!(
+                "local struct: {:?}, params: {:?}",
+                s.get_full_name_str(),
+                s.get_type_parameters()
+            );
+        }
         let mut local_structs: Vec<_> = m_env
             .get_structs()
             .filter_map(|s_env| (!has_type_params(&s_env)).then_some((s_env, vec![])))
@@ -162,6 +179,10 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
         for (s_env, tyvec) in &all_structs {
             assert!(!has_type_params(s_env));
             let ll_name = s_env.ll_struct_name_from_raw_name(tyvec);
+            debug!(target: "structs",
+                   "first pass at create opaque struct {} with tys {:?}",
+                   s_env.get_full_name_str(),
+                   ll_name);
             self.llvm_cx.create_opaque_named_struct(&ll_name);
         }
 
@@ -169,7 +190,12 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
             // Skip the structs that are not fully concretized,
             // i.e. any of the type parameters is not bound to
             // a concrete type.
+            debug!(target: "structs",
+                   "Checking if struct {} is generic with tys {:?}",
+                   s_env.get_full_name_str(),
+                   tys);
             if Self::is_generic_struct(tys) {
+                debug!(target: "structs", "Skipping generic struct");
                 return false;
             }
             let ll_name = s_env.ll_struct_name_from_raw_name(tys);
@@ -189,6 +215,10 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
                 .get_type_actuals(Some(s_def_inst.type_parameters))
                 .unwrap_or_default();
             let s_env = m_env.get_struct_by_def_idx(s_def_inst.def);
+            debug!(target: "structs",
+                   "Found struct instantiation {} with tys {:?}",
+                   s_env.get_full_name_str(),
+                   tys);
             if create_opaque_named_struct(&s_env, &tys) {
                 all_structs.push((s_env, tys));
             }
@@ -201,6 +231,10 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
                 .get_type_actuals(Some(f_inst.type_parameters))
                 .unwrap_or_default();
             let s_env = m_env.get_struct_by_def_idx(fld_handle.owner);
+            debug!(target: "structs",
+                   "Found struct instantiation {} with tys {:?}",
+                   s_env.get_full_name_str(),
+                   tys);
             if create_opaque_named_struct(&s_env, &tys) {
                 all_structs.push((s_env, tys));
             }
@@ -293,7 +327,7 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
         }
         debug!(target: "structs", "Finished translating fields for {ll_name}");
         if self.llvm_cx.named_struct_type(&ll_name).is_none() {
-            debug!(target: "structs", "Create struct {}", &ll_name);
+            debug!(target: "structs", "Create opaque struct {}", &ll_name);
             self.llvm_cx.create_opaque_named_struct(&ll_name);
         }
         let ll_sty = self
@@ -301,6 +335,10 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
             .named_struct_type(&ll_name)
             .expect("no struct type");
         ll_sty.set_struct_body(&ll_field_tys);
+        debug!(target: "structs",
+               "Translated struct {} with fields {:?}",
+               ll_name,
+               ll_field_tys.iter().map(|t| t.print_to_str()).collect::<Vec<_>>());
     }
 
     // This method is used to declare structs found when function
@@ -308,10 +346,15 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
     // structs become known.
     // TODO: porbably other parameterized types such as Vector should
     // be handled by this function too.
-    fn declare_struct_instance(&self, mty: &mty::Type, tyvec: &[mty::Type]) -> llvm::Type {
+    pub fn declare_struct_instance(&self, mty: &mty::Type, tyvec: &[mty::Type]) -> llvm::Type {
+        debug!(target: "structs", "Declaring struct instance {mty:?} with tys {tyvec:?}");
         if let mty::Type::Struct(m, s, _tys) = mty {
             let g_env = &self.env.env;
             let s_env = g_env.get_module(*m).into_struct(*s);
+            debug!(target: "structs",
+                   "Declaring struct instance {} with tys {:?}",
+                   s_env.get_full_name_str(),
+                   tyvec);
             self.translate_struct(&s_env, tyvec);
             self.to_llvm_type(mty, tyvec).unwrap()
         } else {
@@ -720,8 +763,10 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
                     // Pass type parameters and vectors as pointers
                     if mty.is_type_parameter() || mty.is_vector() {
                         llcx.ptr_type()
+                    } else if let Some(ty) = self.to_llvm_type(mty, &[]) {
+                        ty
                     } else {
-                        self.to_llvm_type(mty, &[]).unwrap()
+                        self.declare_struct_instance(mty, &[])
                     }
                 });
 
@@ -819,13 +864,16 @@ impl<'mm: 'up, 'up> ModuleContext<'mm, 'up> {
                         .struct_raw_type_name(tyvec)
                 );
                 // Then process the (possibly type-substituted) struct.
-                if let Type::Struct(declaring_module_id, struct_id, tys) = new_sty {
+                if let Type::Struct(declaring_module_id, struct_id, ref tys) = new_sty {
                     let global_env = &self.env.env;
                     let struct_env = global_env
                         .get_module(declaring_module_id)
                         .into_struct(struct_id);
                     let struct_name = struct_env.ll_struct_name_from_raw_name(&tys);
+                    debug!(
+                        target: "structs", "llvm type for struct {:?} is '{}'", &new_sty, struct_name);
                     if let Some(stype) = self.llvm_cx.named_struct_type(&struct_name) {
+                        debug!( target: "structs", "struct type for '{}' found", &struct_name);
                         Some(stype.as_any_type())
                     } else {
                         debug!(target: "structs", "struct type for '{}' not found", &struct_name);

--- a/crates/move-to-polka/src/stackless/rttydesc.rs
+++ b/crates/move-to-polka/src/stackless/rttydesc.rs
@@ -221,7 +221,7 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
         let g_env = self.g_env;
         let tmty = mty.clone();
         tmty.into_type_tag(g_env)
-            .expect("type tag")
+            .unwrap_or_else(|| panic!("type tag for {mty:?}"))
             .to_canonical_string()
     }
 

--- a/crates/move-to-polka/src/stackless/rttydesc.rs
+++ b/crates/move-to-polka/src/stackless/rttydesc.rs
@@ -233,6 +233,10 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
                 let struct_env = module_env.into_struct(*sid);
                 struct_env.struct_raw_type_name(tys)
             }
+            mty::Type::Vector(inner) => {
+                format!("vector<{}>", self.type_name(inner))
+            }
+            mty::Type::TypeParameter(_) => "type_parameter".to_string(),
             other => {
                 panic!("no name strategy for Move‐type {:?}", other);
             }
@@ -254,6 +258,7 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
             Type::Primitive(PrimitiveType::Signer) => TypeDesc::Signer as u64,
             Type::Vector(_) => TypeDesc::Vector as u64,
             Type::Struct(_, _, _) => TypeDesc::Struct as u64,
+            Type::TypeParameter(_) => 14,
             _ => todo!("{:?}", mty),
         }
     }
@@ -286,6 +291,7 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
                         | Type::Primitive(PrimitiveType::Address)
                         | Type::Primitive(PrimitiveType::Signer)
                         | Type::Vector(_)
+                        | Type::TypeParameter(_)
                         | Type::Struct(_, _, _) => {
                             self.define_type_info_global_vec(&symbol_name, elt_ty)
                         }
@@ -492,6 +498,7 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
                 | PrimitiveType::Address
                 | PrimitiveType::Signer,
             ) => false,
+            Type::TypeParameter(_) => false,
             Type::Vector(_) | Type::Struct(_, _, _) => true,
             _ => todo!(),
         }
@@ -505,7 +512,9 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
                 // A special name for types that don't need type info.
                 "NOTHING".to_string()
             }
-            Type::Vector(_) | Type::Struct(_, _, _) => mty.sanitized_display_name(&tdc),
+            Type::Vector(_) | Type::Struct(_, _, _) | Type::TypeParameter(_) => {
+                mty.sanitized_display_name(&tdc)
+            }
             _ => todo!(),
         };
 

--- a/crates/move-to-polka/src/stackless/rttydesc.rs
+++ b/crates/move-to-polka/src/stackless/rttydesc.rs
@@ -238,7 +238,7 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
             }
             mty::Type::TypeParameter(_) => "type_parameter".to_string(),
             other => {
-                panic!("no name strategy for Move‐type {:?}", other);
+                panic!("no name strategy for Move-type {other:?}");
             }
         }
     }

--- a/crates/move-to-polka/src/stackless/rttydesc.rs
+++ b/crates/move-to-polka/src/stackless/rttydesc.rs
@@ -323,6 +323,7 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
     ///
     /// Defined in the runtime by a `StructTypeInfo` containing `StructFieldInfo`s.
     fn define_type_info_global_struct(&self, symbol_name: &str, mty: &mty::Type) -> llvm::Global {
+        debug!(target: "rtty", "define_type_info_global_struct: {symbol_name}, mty: {mty:?}");
         let llcx = &self.get_llvm_cx();
         let llmod = &self.get_llvm_module();
         let global_env = self.g_env;
@@ -342,7 +343,7 @@ impl<'mm, 'up> RttyContext<'mm, 'up> {
         let ll_struct_name = s_env.ll_struct_name_from_raw_name(s_tys);
         let ll_struct_ty = llcx
             .named_struct_type(&ll_struct_name)
-            .expect("no struct type");
+            .unwrap_or_else(|| panic!("no struct type: {ll_struct_name}"));
         let dl = llmod.get_module_data_layout();
         let ll_struct_size = llcx.abi_size_of_type(dl, ll_struct_ty.as_any_type());
         let ll_struct_align = llcx.abi_alignment_of_type(dl, ll_struct_ty.as_any_type());

--- a/crates/move-to-polka/src/stackless/translate.rs
+++ b/crates/move-to-polka/src/stackless/translate.rs
@@ -287,6 +287,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                 if let Some(s) = named_locals.get(&i) {
                     name = format!("local_{i}__{s}");
                 }
+                debug!(target: "functions", "local {i}: {mty:?} -> {llty:?} ({name})");
                 let llval = self.module_cx.llvm_builder.build_alloca(llty, &name);
                 self.locals.push(Local {
                     mty: mty.instantiate(self.type_params),
@@ -1275,9 +1276,11 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
                     .get_global_env()
                     .get_module(*mod_id)
                     .into_struct(*struct_id);
+                debug!(target: "dwarf", "translate_call Pack {mod_id:?} {struct_id:?} types {types:?}");
                 assert_eq!(dst.len(), 1);
                 assert_eq!(src.len(), struct_env.get_field_count());
                 let struct_name = struct_env.ll_struct_name_from_raw_name(&types);
+                debug!(target: "dwarf", "Pack struct_name {struct_name}");
                 let stype = self
                     .module_cx
                     .llvm_cx

--- a/crates/move-to-polka/src/stackless/translate.rs
+++ b/crates/move-to-polka/src/stackless/translate.rs
@@ -1713,6 +1713,7 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             let fn_id = fun_id.qualified(mod_id);
             let fn_env = global_env.get_function(fn_id);
             if fn_env.is_native() {
+                debug!(target: "functions", "translate_fun_call native function {fn_id:?}");
                 return self.translate_native_fun_call(mod_id, fun_id, types, dst, src, instr);
             }
         }
@@ -2082,6 +2083,12 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
             }
             RtCall::BorrowGlobal(address, ll_type, is_mut) => {
                 debug!(target: "rtcall", "BorrowGlobal ll_type {ll_type:?}");
+
+                if self.module_cx.to_llvm_type(ll_type, &[]).is_none() {
+                    debug!(target: "rtcall", "borrow_global 2");
+                    self.module_cx.declare_struct_instance(ll_type, &[]);
+                    debug!(target: "rtcall", "borrow_global 3");
+                }
                 let llfn = ModuleContext::get_runtime_function(
                     self.module_cx.llvm_cx,
                     self.module_cx.llvm_module,

--- a/crates/move-to-polka/src/stackless/translate.rs
+++ b/crates/move-to-polka/src/stackless/translate.rs
@@ -1980,6 +1980,19 @@ impl<'mm, 'up> FunctionContext<'mm, 'up> {
     }
 
     fn emit_rtcall(&self, rtcall: RtCall, dst: &[mast::TempIndex], _instr: &sbc::Bytecode) {
+        match rtcall {
+            RtCall::MoveTo(_, _, ref ll_type)
+            | RtCall::MoveFrom(_, ref ll_type)
+            | RtCall::BorrowGlobal(_, ref ll_type, _)
+            | RtCall::Release(_, _, ref ll_type)
+            | RtCall::Exists(_, ref ll_type) => {
+                if let mty::Type::Struct(_mod_id, _struct_id, ref tys) = ll_type {
+                    // test and potentially declare the struct instance
+                    self.module_cx.to_llvm_type(ll_type, tys.as_slice());
+                }
+            }
+            _ => {}
+        }
         match &rtcall {
             RtCall::Abort(local_idx) => {
                 let llfn = ModuleContext::get_runtime_function(

--- a/crates/move-to-polka/tests/coin-swap.rs
+++ b/crates/move-to-polka/tests/coin-swap.rs
@@ -1,0 +1,47 @@
+use std::collections::HashSet;
+
+use move_to_polka::{
+    initialize_logger,
+    linker::{copy_to_guest, create_blob, create_instance},
+};
+use once_cell::sync::OnceCell;
+use polkavm::ProgramBlob;
+use polkavm_move_native::types::{MoveAddress, MoveSigner, ACCOUNT_ADDRESS_LENGTH};
+
+static COMPILE_ONCE: OnceCell<ProgramBlob> = OnceCell::new();
+
+fn create_blob_once() -> ProgramBlob {
+    COMPILE_ONCE
+        .get_or_init(|| {
+            initialize_logger();
+            create_blob(
+                "output/coin-swap/coin-swap.polkavm",
+                "../../examples/coin-swap/",
+                HashSet::new(),
+            )
+            .expect("Failed to compile Move source to PolkaVM bytecode")
+        })
+        .clone()
+}
+
+#[test]
+pub fn test_coin_swap() -> anyhow::Result<()> {
+    initialize_logger();
+    let blob = create_blob_once();
+    let (mut instance, mut runtime) = create_instance(blob)?;
+    let mut address_bytes = [1u8; ACCOUNT_ADDRESS_LENGTH];
+    // set markers for debug displaying
+    address_bytes[0] = 0xab;
+    address_bytes[ACCOUNT_ADDRESS_LENGTH - 1] = 0xce;
+
+    let move_signer = MoveSigner(MoveAddress(address_bytes));
+
+    let signer_address = copy_to_guest(&mut instance, &mut runtime.allocator, &move_signer)?;
+
+    let result = instance
+        .call_typed_and_get_result::<(), _>(&mut runtime, "main", (signer_address,))
+        .map_err(|e| anyhow::anyhow!("{e:?}"));
+    assert!(result.is_ok());
+
+    Ok(())
+}

--- a/crates/move-to-polka/tests/taohe.rs
+++ b/crates/move-to-polka/tests/taohe.rs
@@ -1,0 +1,47 @@
+use std::collections::HashSet;
+
+use move_to_polka::{
+    initialize_logger,
+    linker::{copy_to_guest, create_blob, create_instance},
+};
+use once_cell::sync::OnceCell;
+use polkavm::ProgramBlob;
+use polkavm_move_native::types::{MoveAddress, MoveSigner, ACCOUNT_ADDRESS_LENGTH};
+
+static COMPILE_ONCE: OnceCell<ProgramBlob> = OnceCell::new();
+
+fn create_blob_once() -> ProgramBlob {
+    COMPILE_ONCE
+        .get_or_init(|| {
+            initialize_logger();
+            create_blob(
+                "output/taohe/taohe.polkavm",
+                "../../examples/taohe/",
+                HashSet::new(),
+            )
+            .expect("Failed to compile Move source to PolkaVM bytecode")
+        })
+        .clone()
+}
+
+#[test]
+pub fn test_taohe() -> anyhow::Result<()> {
+    initialize_logger();
+    let blob = create_blob_once();
+    let (mut instance, mut runtime) = create_instance(blob)?;
+    let mut address_bytes = [1u8; ACCOUNT_ADDRESS_LENGTH];
+    // set markers for debug displaying
+    address_bytes[0] = 0xab;
+    address_bytes[ACCOUNT_ADDRESS_LENGTH - 1] = 0xce;
+
+    let move_signer = MoveSigner(MoveAddress(address_bytes));
+
+    let signer_address = copy_to_guest(&mut instance, &mut runtime.allocator, &move_signer)?;
+
+    let result = instance
+        .call_typed_and_get_result::<(), _>(&mut runtime, "main", (signer_address,))
+        .map_err(|e| anyhow::anyhow!("{e:?}"));
+    assert!(result.is_ok());
+
+    Ok(())
+}

--- a/crates/move-to-polka/tests/taohe.rs
+++ b/crates/move-to-polka/tests/taohe.rs
@@ -41,6 +41,7 @@ pub fn test_taohe() -> anyhow::Result<()> {
     let result = instance
         .call_typed_and_get_result::<(), _>(&mut runtime, "main", (signer_address,))
         .map_err(|e| anyhow::anyhow!("{e:?}"));
+    println!("Result: {result:?}");
     assert!(result.is_ok());
 
     Ok(())

--- a/crates/polkavm-move-native/src/storage.rs
+++ b/crates/polkavm-move-native/src/storage.rs
@@ -160,6 +160,7 @@ impl Storage for GlobalStorage {
         let value = self.storage.get_mut(&key).ok_or_else(|| {
             ProgramError::MemoryAccess(format!("global not found at {address:?}"))
         })?;
+        debug!("Found global value: {value:?} at address {address:?} with type {tag:x?}");
         let rv = value.data.clone();
         if remove {
             self.storage.remove(&key);

--- a/crates/polkavm-move-native/src/types.rs
+++ b/crates/polkavm-move-native/src/types.rs
@@ -56,7 +56,7 @@ pub struct MoveSignerVector {
 ///
 /// The pointer must be to static memory and never mutated.
 ///
-/// NOTE: The `type_info` pointer and name are only valid in guest memory.
+/// NOTE: The `type_info` pointer is only valid in guest memory.
 #[repr(C)]
 #[derive(Copy, Clone, Eq, Hash, PartialEq)]
 pub struct MoveType {

--- a/examples/basic-coin/Move.toml
+++ b/examples/basic-coin/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "BasicCoin"
+version = "0.0.0"
+
+[addresses]
+BasicCoin = "0xBC"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move-on-aptos.git", subdir = "language/move-stdlib", rev = "main", addr_subst = { "std" = "0x1" } }

--- a/examples/basic-coin/sources/BasicCoin.move
+++ b/examples/basic-coin/sources/BasicCoin.move
@@ -1,0 +1,150 @@
+/// This module defines a minimal and generic Coin and Balance.
+module BasicCoin::BasicCoin {
+    use std::error;
+    use std::signer;
+
+    /// Error codes
+    const ENOT_MODULE_OWNER: u64 = 0;
+    const EINSUFFICIENT_BALANCE: u64 = 1;
+    const EALREADY_HAS_BALANCE: u64 = 2;
+    const EALREADY_INITIALIZED: u64 = 3;
+    const EEQUAL_ADDR: u64 = 4;
+
+    struct Coin<phantom CoinType> has store {
+        value: u64
+    }
+
+    struct Balance<phantom CoinType> has key {
+        coin: Coin<CoinType>
+    }
+
+    public fun publish_balance<CoinType>(account: &signer) {
+        let empty_coin = Coin<CoinType> { value: 0 };
+        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), error::already_exists(EALREADY_HAS_BALANCE));
+        move_to(account, Balance<CoinType> { coin:  empty_coin });
+    }
+
+    spec publish_balance {
+        include Schema_publish<CoinType> {addr: signer::address_of(account), amount: 0};
+    }
+
+    spec schema Schema_publish<CoinType> {
+        addr: address;
+        amount: u64;
+
+        aborts_if exists<Balance<CoinType>>(addr);
+
+        ensures exists<Balance<CoinType>>(addr);
+        let post balance_post = global<Balance<CoinType>>(addr).coin.value;
+
+        ensures balance_post == amount;
+    }
+
+    /// Mint `amount` tokens to `mint_addr`. This method requires a witness with `CoinType` so that the
+    /// module that owns `CoinType` can decide the minting policy.
+    public fun mint<CoinType: drop>(mint_addr: address, amount: u64, _witness: CoinType) acquires Balance {
+        // Deposit `amount` of tokens to mint_addr's balance
+        deposit(mint_addr, Coin<CoinType> { value: amount });
+    }
+
+    spec mint {
+        include DepositSchema<CoinType> {addr: mint_addr, amount};
+    }
+
+    /// Burn `amount` tokens from `burn_addr`. This method requires a witness with `CoinType` so that the
+    /// module that owns `CoinType` can decide the burning policy.
+    public fun burn<CoinType: drop>(burn_addr: address, amount: u64, _witness: CoinType) acquires Balance {
+        // Withdraw `amount` of tokens from mint_addr's balance
+        let Coin { value: _ } = withdraw<CoinType>(burn_addr, amount);
+    }
+
+    spec burn {
+        // TBD
+    }
+
+
+    public fun balance_of<CoinType>(owner: address): u64 acquires Balance {
+        borrow_global<Balance<CoinType>>(owner).coin.value
+    }
+
+    spec balance_of {
+        pragma aborts_if_is_strict;
+        aborts_if !exists<Balance<CoinType>>(owner);
+    }
+
+    /// Transfers `amount` of tokens from `from` to `to`. This method requires a witness with `CoinType` so that the
+    /// module that owns `CoinType` can decide the transferring policy.
+    public fun transfer<CoinType: drop>(from: &signer, to: address, amount: u64, _witness: CoinType) acquires Balance {
+        let from_addr = signer::address_of(from);
+        assert!(from_addr != to, EEQUAL_ADDR);
+        let check = withdraw<CoinType>(from_addr, amount);
+        deposit<CoinType>(to, check);
+    }
+
+    spec transfer {
+        let addr_from = signer::address_of(from);
+
+        let balance_from = global<Balance<CoinType>>(addr_from).coin.value;
+        let balance_to = global<Balance<CoinType>>(to).coin.value;
+        let post balance_from_post = global<Balance<CoinType>>(addr_from).coin.value;
+        let post balance_to_post = global<Balance<CoinType>>(to).coin.value;
+
+        aborts_if !exists<Balance<CoinType>>(addr_from);
+        aborts_if !exists<Balance<CoinType>>(to);
+        aborts_if balance_from < amount;
+        aborts_if balance_to + amount > MAX_U64;
+        aborts_if addr_from == to;
+
+        ensures balance_from_post == balance_from - amount;
+        ensures balance_to_post == balance_to + amount;
+    }
+
+    fun withdraw<CoinType>(addr: address, amount: u64) : Coin<CoinType> acquires Balance {
+        let balance = balance_of<CoinType>(addr);
+        assert!(balance >= amount, EINSUFFICIENT_BALANCE);
+        let balance_ref = &mut borrow_global_mut<Balance<CoinType>>(addr).coin.value;
+        *balance_ref = balance - amount;
+        Coin<CoinType> { value: amount }
+    }
+
+    spec withdraw {
+        let balance = global<Balance<CoinType>>(addr).coin.value;
+
+        aborts_if !exists<Balance<CoinType>>(addr);
+        aborts_if balance < amount;
+
+        let post balance_post = global<Balance<CoinType>>(addr).coin.value;
+        ensures result == Coin<CoinType> { value: amount };
+        ensures balance_post == balance - amount;
+    }
+
+    fun deposit<CoinType>(addr: address, check: Coin<CoinType>) acquires Balance{
+        let balance = balance_of<CoinType>(addr);
+        let balance_ref = &mut borrow_global_mut<Balance<CoinType>>(addr).coin.value;
+        let Coin { value } = check;
+        *balance_ref = balance + value;
+    }
+
+    spec deposit {
+        let balance = global<Balance<CoinType>>(addr).coin.value;
+        let check_value = check.value;
+
+        aborts_if !exists<Balance<CoinType>>(addr);
+        aborts_if balance + check_value > MAX_U64;
+
+        let post balance_post = global<Balance<CoinType>>(addr).coin.value;
+        ensures balance_post == balance + check_value;
+    }
+
+    spec schema DepositSchema<CoinType> {
+        addr: address;
+        amount: u64;
+        let balance = global<Balance<CoinType>>(addr).coin.value;
+
+        aborts_if !exists<Balance<CoinType>>(addr);
+        aborts_if balance + amount > MAX_U64;
+
+        let post balance_post = global<Balance<CoinType>>(addr).coin.value;
+        ensures balance_post == balance + amount;
+    }
+}

--- a/examples/coin-swap/Move.toml
+++ b/examples/coin-swap/Move.toml
@@ -1,0 +1,14 @@
+[package]
+name = "CoinSwap"
+version = "0.0.0"
+
+[addresses]
+std = "0x1"
+CoinSwap = "0xC5"
+BasicCoin = "0xBC"
+GoldCoin = "0x9C"
+SilverCoin = "0x5C"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move-on-aptos.git", subdir = "language/move-stdlib", rev = "main", addr_subst = { "std" = "0x1" } }
+BasicCoin = { local = "../basic-coin" }

--- a/examples/coin-swap/sources/CoinSwap.move
+++ b/examples/coin-swap/sources/CoinSwap.move
@@ -1,0 +1,109 @@
+module CoinSwap::CoinSwap {
+    use std::signer;
+    use std::error;
+    use BasicCoin::BasicCoin;
+    use CoinSwap::PoolToken;
+
+    const ECOINSWAP_ADDRESS: u64 = 0;
+    const EPOOL: u64 = 0;
+
+    struct LiquidityPool<phantom CoinType1, phantom CoinType2> has key {
+        coin1: u64,
+        coin2: u64,
+        share: u64,
+    }
+
+    public fun create_pool<CoinType1: drop, CoinType2: drop>(
+        coinswap: &signer,
+        requester: &signer,
+        coin1: u64,
+        coin2: u64,
+        share: u64,
+        witness1: CoinType1,
+        witness2: CoinType2
+    ) {
+        // Create a pool at @CoinSwap.
+        // TODO: If the balance is already published, this step should be skipped rather than abort.
+        // TODO: Alternatively, `struct LiquidityPool` could be refactored to actually hold the coin (e.g., coin1: CoinType1).
+        BasicCoin::publish_balance<CoinType1>(coinswap);
+        BasicCoin::publish_balance<CoinType2>(coinswap);
+        assert!(signer::address_of(coinswap) == @CoinSwap, error::invalid_argument(ECOINSWAP_ADDRESS));
+        assert!(!exists<LiquidityPool<CoinType1, CoinType2>>(signer::address_of(coinswap)), error::already_exists(EPOOL));
+        move_to(coinswap, LiquidityPool<CoinType1, CoinType2>{coin1, coin2, share});
+
+        // Transfer the initial liquidity of CoinType1 and CoinType2 to the pool under @CoinSwap.
+        BasicCoin::transfer<CoinType1>(requester, signer::address_of(coinswap), coin1, witness1);
+        BasicCoin::transfer<CoinType2>(requester, signer::address_of(coinswap), coin2, witness2);
+
+        // Mint PoolToken and deposit it in the account of requester.
+        PoolToken::setup_and_mint<CoinType1, CoinType2>(requester, share);
+    }
+
+    fun get_input_price(input_amount: u64, input_reserve: u64, output_reserve: u64): u64 {
+        let input_amount_with_fee = input_amount * 997;
+        let numerator = input_amount_with_fee * output_reserve;
+        let denominator = (input_reserve * 1000) + input_amount_with_fee;
+        numerator / denominator
+    }
+
+    public fun coin1_to_coin2_swap_input<CoinType1: drop, CoinType2: drop>(
+        coinswap: &signer,
+        requester: &signer,
+        coin1: u64,
+        witness1: CoinType1,
+        witness2: CoinType2
+    ) acquires LiquidityPool {
+        assert!(signer::address_of(coinswap) == @CoinSwap, error::invalid_argument(ECOINSWAP_ADDRESS));
+        assert!(exists<LiquidityPool<CoinType1, CoinType2>>(signer::address_of(coinswap)), error::not_found(EPOOL));
+        let pool = borrow_global_mut<LiquidityPool<CoinType1, CoinType2>>(signer::address_of(coinswap));
+        let coin2 = get_input_price(coin1, pool.coin1, pool.coin2);
+        pool.coin1 = pool.coin1 + coin1;
+        pool.coin2 = pool.coin2 - coin2;
+
+        BasicCoin::transfer<CoinType1>(requester, signer::address_of(coinswap), coin1, witness1);
+        BasicCoin::transfer<CoinType2>(coinswap, signer::address_of(requester), coin2, witness2);
+    }
+
+    public fun add_liquidity<CoinType1: drop, CoinType2: drop>(
+        account: &signer,
+        coin1: u64,
+        coin2: u64,
+        witness1: CoinType1,
+        witness2: CoinType2,
+    ) acquires LiquidityPool {
+        let pool = borrow_global_mut<LiquidityPool<CoinType1, CoinType2>>(@CoinSwap);
+
+        let coin1_added = coin1;
+        let share_minted = (coin1_added * pool.share) / pool.coin1;
+        let coin2_added = (share_minted * pool.coin2) / pool.share;
+
+        pool.coin1 = pool.coin1 + coin1_added;
+        pool.coin2 = pool.coin2 + coin2_added;
+        pool.share = pool.share + share_minted;
+
+        BasicCoin::transfer<CoinType1>(account, @CoinSwap, coin1, witness1);
+        BasicCoin::transfer<CoinType2>(account, @CoinSwap, coin2, witness2);
+        PoolToken::mint<CoinType1, CoinType2>(signer::address_of(account), share_minted)
+    }
+
+    public fun remove_liquidity<CoinType1: drop, CoinType2: drop>(
+        coinswap: &signer,
+        requester: &signer,
+        share: u64,
+        witness1: CoinType1,
+        witness2: CoinType2,
+    ) acquires LiquidityPool {
+        let pool = borrow_global_mut<LiquidityPool<CoinType1, CoinType2>>(@CoinSwap);
+
+        let coin1_removed = (pool.coin1 * share) / pool.share;
+        let coin2_removed = (pool.coin2 * share) / pool.share;
+
+        pool.coin1 = pool.coin1 - coin1_removed;
+        pool.coin2 = pool.coin2 - coin2_removed;
+        pool.share = pool.share - share;
+
+        BasicCoin::transfer<CoinType1>(coinswap, signer::address_of(requester), coin1_removed, witness1);
+        BasicCoin::transfer<CoinType2>(coinswap, signer::address_of(requester), coin2_removed, witness2);
+        PoolToken::burn<CoinType1, CoinType2>(signer::address_of(requester), share)
+    }
+}

--- a/examples/coin-swap/sources/GoldCoin.move
+++ b/examples/coin-swap/sources/GoldCoin.move
@@ -1,0 +1,19 @@
+module GoldCoin::GoldCoin {
+    use std::signer;
+    use BasicCoin::BasicCoin;
+
+    struct GoldCoin has drop {}
+
+    public fun setup_and_mint(account: &signer, amount: u64) {
+        BasicCoin::publish_balance<GoldCoin>(account);
+        BasicCoin::mint<GoldCoin>(signer::address_of(account), amount, GoldCoin{});
+    }
+
+    public fun transfer(from: &signer, to: address, amount: u64) {
+        BasicCoin::transfer<GoldCoin>(from, to, amount, GoldCoin {});
+    }
+
+    public entry fun main(account: &signer) {
+        setup_and_mint(account, 5);
+    }
+}

--- a/examples/coin-swap/sources/PoolToken.move
+++ b/examples/coin-swap/sources/PoolToken.move
@@ -1,0 +1,25 @@
+module CoinSwap::PoolToken {
+    use std::signer;
+    use BasicCoin::BasicCoin;
+
+    struct PoolToken<phantom CoinType1, phantom CoinType2> has drop {}
+
+    public fun setup_and_mint<CoinType1, CoinType2>(account: &signer, amount: u64) {
+        BasicCoin::publish_balance<PoolToken<CoinType1, CoinType2>>(account);
+        BasicCoin::mint<PoolToken<CoinType1, CoinType2>>(signer::address_of(account), amount, PoolToken {});
+    }
+
+    public fun transfer<CoinType1, CoinType2>(from: &signer, to: address, amount: u64) {
+        BasicCoin::transfer<PoolToken<CoinType1, CoinType2>>(from, to, amount, PoolToken<CoinType1, CoinType2> {});
+    }
+
+    public fun mint<CoinType1, CoinType2>(mint_addr: address, amount: u64) {
+        // Deposit `total_value` amount of tokens to mint_addr's balance
+        BasicCoin::mint(mint_addr, amount, PoolToken<CoinType1, CoinType2> {});
+    }
+
+    public fun burn<CoinType1, CoinType2>(burn_addr: address, amount: u64) {
+        // Deposit `total_value` amount of tokens to mint_addr's balance
+        BasicCoin::burn(burn_addr, amount, PoolToken<CoinType1, CoinType2> {});
+    }
+}

--- a/examples/coin-swap/sources/SilverCoin.move
+++ b/examples/coin-swap/sources/SilverCoin.move
@@ -1,0 +1,15 @@
+module SilverCoin::SilverCoin {
+    use std::signer;
+    use BasicCoin::BasicCoin;
+
+    struct SilverCoin has drop {}
+
+    public fun setup_and_mint(account: &signer, amount: u64) {
+        BasicCoin::publish_balance<SilverCoin>(account);
+        BasicCoin::mint<SilverCoin>(signer::address_of(account), amount, SilverCoin {});
+    }
+
+    public fun transfer(from: &signer, to: address, amount: u64) {
+        BasicCoin::transfer<SilverCoin>(from, to, amount, SilverCoin {});
+    }
+}

--- a/examples/taohe/Move.toml
+++ b/examples/taohe/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taoho"
+name = "taohe"
 version = "1.0.0"
 
 [addresses]

--- a/examples/taohe/Move.toml
+++ b/examples/taohe/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "taoho"
+version = "1.0.0"
+
+[addresses]
+TaoHe = "0x2f66c09143acc52a85fec529a4e20c85"
+Connector = "0x2f66c09143acc52a85fec529a4e20c85"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move-on-aptos.git", subdir = "language/move-stdlib", rev = "main", addr_subst = { "std" = "0x1" } }
+TaoHe = { git = "https://github.com/taoheorg/taohe.git", rev = "main" }
+Connector = { git = "https://github.com/taoheorg/connector-dummy.git", rev = "2125806ade4a1b0995c370524e69c7c3a864724e" }

--- a/examples/taohe/sources/entry.move
+++ b/examples/taohe/sources/entry.move
@@ -1,5 +1,9 @@
+module 0x10::debug {
+    native public fun print<T>(x: &T);
+}
 module 0x42::entry {
     use std::signer;
+    use 0x10::debug;
     use TaoHe::root;
 
     struct MyContent has store, key{
@@ -8,6 +12,8 @@ module 0x42::entry {
 
     public entry fun main(account: &signer) {
         let content = MyContent { id: 1 };
+        debug::print(&content);
         root::create(account, content);
+        debug::print(&b"done");
     }
 }

--- a/examples/taohe/sources/entry.move
+++ b/examples/taohe/sources/entry.move
@@ -1,0 +1,13 @@
+module 0x42::entry {
+    use std::signer;
+    use TaoHe::root;
+
+    struct MyContent has store, key{
+        id: u64,
+    }
+
+    public entry fun main(account: &signer) {
+        let content = MyContent { id: 1 };
+        root::create(account, content);
+    }
+}


### PR DESCRIPTION
- fix struct concretization
- add Move projects from external sources
- don't emit `move_rt_release` if the pointer is null:

> in the TaoHe sample, there is a conditional `borrow_global`. We always generate a `release` when we see a `borrow_global`, as we can't know which branch will be taken at compile time. But if the borrow branch isn't taken, we would generate a release on a garbage pointer. Fix is to initialize all allocas to null (or zero) and check for null before generating `release`.